### PR TITLE
Added check for street prefix "ul", "ulica"

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -171,7 +171,7 @@ OVERPASS_CATEGORIES: tuple[Category, ...] = (
 
                 critical=True,
                 desc="Nazwa ulicy nie powinna zawierać przedrostka.",
-                extra="Nazwa ulicy nie powinna zaczynać się od 'ul.', 'ulica ' itp."
+                extra="Nazwa ulicy nie powinna zaczynać się od 'ul.', 'ulica' itp. "
                       "Należy usunąć przedrostek i pozostawić samą nazwę ulicy.",
 
                 docs="Zasady nazewnictwa ulic w polsce:\n"

--- a/checks.py
+++ b/checks.py
@@ -12,6 +12,7 @@ WEBSITE_PROTOCOL_RE = re.compile(r'^\w{2,}://')
 WEBSITE_DUPLICATED_PROTOCOL_RE = re.compile(r'^\w{2,}://\w{2,}://')
 WEBSITE_SHORTENER_RE = re.compile(r'^\w{2,}://(www\.)?(tinyurl\.com|tiny\.(cc|pl)|(bit|cutt)\.ly|[gt]\.co|goo\.gl(?!/maps))/',
                                   re.IGNORECASE)
+STREET_NAME_BAD_PREFIX = re.compile(r'^ul(ica)?\.? ')
 
 OVERPASS_CATEGORIES: tuple[Category, ...] = (
     Category(
@@ -163,6 +164,22 @@ OVERPASS_CATEGORIES: tuple[Category, ...] = (
                 selectors=('addr:street',),
                 post_fn=lambda o, i: o.query_street_names(i)
             ),
+
+            Check(
+                identifier="STREET_NAME_WITH_PREFIX",
+                priority=15,
+
+                critical=True,
+                desc="Nazwa ulicy nie powinna zawierać przedrostka.",
+                extra="Nazwa ulicy nie powinna zaczynać się od 'ul.', 'ulica ' itp."
+                      "Należy usunąć przedrostek i pozostawić samą nazwę ulicy.",
+
+                docs="Zasady nazewnictwa ulic w polsce:\n"
+                "https://wiki.osm.org/Pl:Znakowanie_dróg_w_Polsce#Nazewnictwo_ulic",
+
+                selectors=("addr:street"),
+                pre_fn=lambda t: STREET_NAME_BAD_PREFIX.match(t["addr:street"])
+            )
         )
     ),
 


### PR DESCRIPTION
As pointed in issue #5  - added check for prefix `ul` / `ulica`

Exemplary tagging to be reported as error:

```
highway=residential
name=ul. Główna
```