### PR TITLE
 Added check for proposed=* key not removed #13 

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -300,6 +300,25 @@ OVERPASS_CATEGORIES: list[Category] = [
                     t.get('railway')
                 )
             ),
+
+            Check(
+                identifier='PROPOSED_NOT_REMOVED',
+
+                critical=False,
+                desc='Klucz proposed=* nie został usunięty.',
+                extra='Jeżeli proponowana budowa została rozpoczęta lub plany zmieniły się w inny sposób, należy usunąć dotychczasowe tagowanie wskazujące na propozycję budowy.',
+
+                docs=None,
+
+                selectors=('proposed'),
+                pre_fn=lambda t: \
+                t['proposed'] in (
+                    t.get('building'),
+                    t.get('landuse'),
+                    t.get('highway'),
+                    t.get('railway')
+                )
+            ),
         ]
     ),
 ]


### PR DESCRIPTION
As discussed at [OSM Community forum](https://community.openstreetmap.org/t/propozycja-automatycznej-edycji-usuniecie-proposed-x-jesli-highway-x/111490/3) - added check for not removing `proposed=*` tags.

Exemplary tagging to be reported as error:

```
highway=proposed
proposed=residential
```

It's intended for changes when user forgets to remove `proposed=*` after construction is started/dropped.

This PR is similar to #13 